### PR TITLE
Knights code update for 4.0

### DIFF
--- a/BeachBall.js
+++ b/BeachBall.js
@@ -14,7 +14,7 @@ for (var decree in Molpy.PapalDecrees) {
 BeachBall.popeGrace = 0;
 
 //Version Information
-BeachBall.version = '5.6.2';
+BeachBall.version = '5.6.4';
 BeachBall.SCBversion = '4.0'; //Last SandCastle Builder version tested
 
 // NOTE: Tons of audio code has been commented.
@@ -1433,8 +1433,8 @@ BeachBall.LoadSettings = function() {
 		
 		// Do setting conversion here if required
 		if (oldVersion) {
-			// 5.6.2 removed placeholder setting from Knights at index 2
-			if (BeachBall.VerCompare(oldVersion, '5.6.2') < 0) {
+			// 5.6.4 removed placeholder setting from Knights at index 2
+			if (BeachBall.VerCompare(oldVersion, '5.6.4') < 0) {
 				var ka = Number(localStorage['BB.KnightActions.status']);
 				if (ka >= 2) {
 					localStorage['BB.KnightActions.status'] = ka - 1;

--- a/BeachBall.js
+++ b/BeachBall.js
@@ -872,10 +872,8 @@ BeachBall.RedundaKitty = function() {
 			if (meKnight.status == 1) {
 				Molpy.DragonKnightAttack();
 			} else if (meKnight.status == 2) {
-				Molpy.DragonKnightAttack(1);
-			} else if (meKnight.status == 3) {
 				Molpy.DragonKnightAttack(2);
-			} else if (meKnight.status == 4) {
+			} else if (meKnight.status == 3) {
 				// Hide the Knight at the less second
 				if (BeachBall.RKTimer <= 3) {
 					Molpy.DragonsHide(0);
@@ -1298,7 +1296,7 @@ BeachBall.LoadDefaultSetting = function (option, key) {
 		if (key == 'status') 	{return 0;}
 		if (key == 'maxStatus') {return 4;}
 		if (key == 'setting')	{return 0;}
-		if (key == 'desc')		{return ['Off', 'Attack', 'Strength Potion', 'Breath<br/>(Placeholder)', 'Hide<br/>(Triggers at <= 3mNP)'];}
+		if (key == 'desc')		{return ['Off', 'Attack', 'Breath<br/>(Placeholder)', 'Hide<br/>(Triggers at <= 3mNP)'];}
 	}
 	else if (option == 'ToolFactory') {
 		if (key == 'title')		{return 'Tool Factory';}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ This feature is performed using the Faves panel instead of the Options panel.
 
 ## Changelog
 
+###Version 5.6.4
+
+####Fixes
+* Removed the "Strength Potion" placeholder option from the Knights options, which never did anything anyway - and now never will.
+* Fixed the "Breath" option for Knights, which wasn't updated for when breath actually became an option in SCB 4.0.
+
 ###Version 5.6.3
 
 ####Changes


### PR DESCRIPTION
v5.6.4

Removed the now useless placeholder for potions, and fixed the previously-placeholder breath option for 4.0
